### PR TITLE
dropped unique cor

### DIFF
--- a/server/prisma/migrations/20250318140105_dropuniquecar/migration.sql
+++ b/server/prisma/migrations/20250318140105_dropuniquecar/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "HeatLane_carId_key";

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -24,7 +24,7 @@ model Car {
   racerId Int? @unique // relation scaler field, the unique decorator means one to one relationship
   year Int?
   image String?
-  lane HeatLane?
+  lane HeatLane[]
 }
 
 model HeatLane {
@@ -32,7 +32,7 @@ model HeatLane {
   lane Int 
   result Int? 
   car Car? @relation(fields: [carId], references: [id])
-  carId Int? @unique
+  carId Int? 
   heatId Int?
   raceId Int?
   raceName String? @db.VarChar(255)


### PR DESCRIPTION
dropped 1:1 unique constraint of heatlane to car, to allow multiple sets of races and heats to exist in same table.  i.e. to support quarterfinals and semis for same car.