### PR TITLE
Semifinals and deadheats logic

### DIFF
--- a/server/src/race/race.module.ts
+++ b/server/src/race/race.module.ts
@@ -3,10 +3,12 @@ import { RaceService } from './race.service';
 import { RaceController } from './race.controller';
 import { HeatLaneModule } from '../heat-lane/heat-lane.module'
 import { PrismaService } from '../prisma/prisma.service';
+import { SemiGlobalVariableService } from './semi.service';
 
 @Module({
   controllers: [RaceController],
-  providers: [RaceService, PrismaService],
-  imports: [HeatLaneModule]
+  providers: [RaceService, PrismaService, SemiGlobalVariableService],
+  imports: [HeatLaneModule],
+  exports: [SemiGlobalVariableService]
 })
 export class RaceModule {}

--- a/server/src/race/race.service.ts
+++ b/server/src/race/race.service.ts
@@ -143,7 +143,7 @@ export class RaceService {
     return cars;
   }
 
-  async createSemi(createRaceDto: CreateRaceDto): Promise<HeatLane[]> {
+  async createSemi(createRaceDto: CreateRaceDto) {
   
     //set variable for number of lanes from API parameter input
     const numLanes = createRaceDto.numLanes;
@@ -159,12 +159,6 @@ export class RaceService {
     const inputRole = createRaceDto.role;
 
     let heats : HeatLane[] = [];
-
-    const heatCount = await this.prisma.heatLane.count({
-      select: {
-        _all: true, // Count all records
-      },
-    })
 
     //need to find all the car ids that aren't blank
     //find out how many cars are in the car table overall
@@ -217,6 +211,8 @@ export class RaceService {
 
     //find all the results in a set of races for each non-blank car id
 
+    let totalResultsIndex = 0;
+
     //loop through all heatlanes of non-blank cars that match the input role
     //note racename should be "quarterfinals" first
     for(let i = 0; i < cars.length; i++){
@@ -237,22 +233,27 @@ export class RaceService {
         },
       })
 
-      //console.log("selectHeats of car id ", cars[i].id, " :", selectHeats);
+      console.log("selectHeats of car id ", cars[i].id, " :", selectHeats);
       
-      totalResults.push({
-          carId: cars[i].id,
-          aggResults: 0,
-      });
+      if(selectHeats.length > 0) {
+        console.log("select Heats is not null");
+        totalResults.push({
+            carId: cars[i].id,
+            aggResults: 0,
+        });
 
-      //sum up results for each car 
-      for(let j = 0; j < selectHeats.length; j++){
-        //the ?? syntax is because that value could be null
-        totalResults[i].aggResults = totalResults[i].aggResults + (selectHeats[j].result ?? 0); 
+        totalResultsIndex = totalResults.length-1;
+
+        //sum up results for each car 
+        for(let j = 0; j < selectHeats.length; j++){
+          totalResults[totalResultsIndex].aggResults = totalResults[totalResultsIndex].aggResults + (selectHeats[j].result ?? 0); 
+        }
+
       }
     }
 
-    //summed up results.  Note, this likely needs to be a table not an array
-    //console.log("totalresults: ", totalResults);
+    //summed up results.  
+    console.log("totalresults: ", totalResults);
 
     //total number of semifinal participants
     const numSemiLanes = numLanes * 2; 
@@ -267,10 +268,16 @@ export class RaceService {
     console.log("sortedResult: ", sortedResult);
 
     //check if there are any ties
-    //find last place first
-    const lastPlaceAggResults = sortedResult[numSemiLanes-1].aggResults;
+    
+    let lastPlaceAggResults = 0;
 
-    console.log("last place: ", sortedResult[numSemiLanes-1].carId);
+    //find last place  but only if this isn't a deadheat
+    if(totalResults.length > numSemiLanes){
+      lastPlaceAggResults = sortedResult[numSemiLanes-1].aggResults;
+      console.log("last place: ", sortedResult[numSemiLanes-1].carId);
+      //you only want to do this if this isn't a deadheat
+      this.numAdvances.initAdvanceToSemis();  
+    }
 
     const deadHeat = [
       { 
@@ -281,15 +288,8 @@ export class RaceService {
 
     deadHeat.length = 0;
 
-    const advanceToSemis = [
-      { 
-        carId: 0,
-        aggResults: 0, 
-      },
-    ];
-    
-    advanceToSemis.length = 0;
-    
+    let advanceToSemis = this.numAdvances.getAdvanceToSemis();
+
     //Check how many can advance if this is the deadheat one
     //numSemiLanes is the total number that can advance if this is quarterfinals
 
@@ -320,7 +320,7 @@ export class RaceService {
     //if there is tie for last place, then need to look through the start of the array again for all ties and add that to deadheat; else goes to advance
     if(deadHeat.length > 0){
       for(let i = 0; i < sortedResult.length; i++){
-        if(i <= checkNumAdvances ){
+        if(i < checkNumAdvances ){
           if(sortedResult[i].aggResults === lastPlaceAggResults){
             deadHeat.push({
               carId: sortedResult[i].carId,
@@ -355,21 +355,23 @@ export class RaceService {
       //add blank cars to make full lanes
       //use this syntax to assign async result because async result can't be assigned directly
       this.addBlankCars(deadHeatCars, numLanes).then(result => deadHeatCars = result);
-
-      //randomly sort the cars including blanks
-      deadHeatCars = this.shuffleSort(deadHeatCars);
-   
-      //console.log("after shuffle: ", cars);
-
+      
       //figure out how many heats are needed
       let numDeadHeats = deadHeatCars.length/numLanes;
 
       let deadHeatRaceName = raceName + "deadHeat";
 
       //assign lanes
-      this.createHeats(numDeadHeats, deadHeatCars, raceId, deadHeatRaceName, inputRole).then(result => heats = result);
+      //using i as raceId 
+      for(let i = 0; i < numDeadHeats; i++){
+        
+        //randomly sort the cars including blanks
+        deadHeatCars = this.shuffleSort(deadHeatCars);
+    
+        //console.log("after shuffle: ", cars);
 
-      //console.log("these deadheat cars are now sorted: ", deadHeatCars);    
+        this.createHeats(numDeadHeats, deadHeatCars, i, deadHeatRaceName, inputRole).then(result => heats = result);
+      }
     }
     //if there isn't, then there's no need for deadheat, because all cars that can advance will advance, and there's no need to care about ties
     else{
@@ -381,37 +383,57 @@ export class RaceService {
           });
         }
       }
+      //save all the cars that advance
+      this.numAdvances.setAdvanceToSemis(advanceToSemis);
     }
 
-    //TODO: revisit when numAdvances gets set, and what to do with the cars that do advance
+    //if greater than zero and less than the total number of advancing possible save in global variable
+    if(advanceToSemis.length > 0 && advanceToSemis.length < numSemiLanes){
+      this.numAdvances.setnumAdvances(advanceToSemis.length);
 
-    this.numAdvances.setnumAdvances(advanceToSemis.length);
+      console.log("this many advanced and need to be saved: " + this.numAdvances.getNumAdvances());
 
-    console.log("this many advanced: " + this.numAdvances.getNumAdvances());
+      //save the partial set of cars that will advance into a global variable
+      this.numAdvances.setAdvanceToSemis(advanceToSemis);
+    }
 
-    console.log("these cars advance to semis: ", advanceToSemis);
+    //instead of an else get all the cars that will advance to check if there's a full set of semis
+    let finalAdvanceToSemis = this.numAdvances.getAdvanceToSemis();
 
-    let advanceToSemisCars : Car[] = [];    
+    if(finalAdvanceToSemis.length === numSemiLanes){
+      
+      console.log("these cars advance to semis: ", finalAdvanceToSemis);
 
-    for(let i = 0; i < advanceToSemis.length; i++){
-      const oneValue = await this.prisma.car.findUnique({
-        where: {
-          id: advanceToSemis[i].carId,
+      let advanceToSemisCars : Car[] = [];    
+
+      for(let i = 0; i < finalAdvanceToSemis.length; i++){
+        const oneValue = await this.prisma.car.findUnique({
+          where: {
+            id: finalAdvanceToSemis[i].carId,
+          }
+        });
+        if(oneValue !== null){
+          advanceToSemisCars.push(oneValue);
         }
-      });
-      if(oneValue !== null){
-        advanceToSemisCars.push(oneValue);
       }
+      
+      //figure out how many heats are needed
+      let numSemiHeats = advanceToSemisCars.length/numLanes;
+
+      let semiRaceName = "semi";
+
+      //using i as raceId 
+      for(let i = 0; i < numSemiHeats; i++){ 
+        //no need to add blanks because will always have a full set of cars advancing
+        //sort the array of cars for each race
+        advanceToSemisCars = this.shuffleSort(advanceToSemisCars);
+
+        //console.log("these advance to semis cars are now sorted: ", advanceToSemisCars);
+       
+        this.createHeats(numSemiHeats, advanceToSemisCars, i, semiRaceName, inputRole).then(result => heats = result);
+      }
+
     }
-
-    //NOTE: shuffle and building semi heats needs to wait until a full semis is available
-    //advanceToSemisCars = this.shuffleSort(advanceToSemisCars);
-
-    //console.log("these advance to semis cars are now sorted: ", advanceToSemisCars);
-
-    //note return is returning deadheats technically ... maybe don't need a return at all? 
-    return heats; 
-
   }
 
   findAll() {

--- a/server/src/race/race.service.ts
+++ b/server/src/race/race.service.ts
@@ -290,12 +290,25 @@ export class RaceService {
     
     advanceToSemis.length = 0;
     
-    //TODO: need to check how many can advance if this is the deadheat one
+    //Check how many can advance if this is the deadheat one
+    //numSemiLanes is the total number that can advance if this is quarterfinals
 
+    let checkNumAdvances = this.numAdvances.getNumAdvances();
+
+    console.log("checkNumAdvances: " + checkNumAdvances);
+
+    if(checkNumAdvances === 0){
+      checkNumAdvances = numSemiLanes;
+    }
+    else{
+      checkNumAdvances = numSemiLanes - checkNumAdvances;
+    }
     
+    console.log("checkNumAdvances after checking for zero value: " + checkNumAdvances);
+
     //need to know if there is a match of last place after the number of advancement slots
     for(let i = 0; i < sortedResult.length; i++){
-      if(i >= numSemiLanes){
+      if(i >= checkNumAdvances){
         if(sortedResult[i].aggResults === lastPlaceAggResults){
           deadHeat.push({
             carId: sortedResult[i].carId,
@@ -307,7 +320,7 @@ export class RaceService {
     //if there is tie for last place, then need to look through the start of the array again for all ties and add that to deadheat; else goes to advance
     if(deadHeat.length > 0){
       for(let i = 0; i < sortedResult.length; i++){
-        if(i <= numSemiLanes ){
+        if(i <= checkNumAdvances ){
           if(sortedResult[i].aggResults === lastPlaceAggResults){
             deadHeat.push({
               carId: sortedResult[i].carId,
@@ -361,7 +374,7 @@ export class RaceService {
     //if there isn't, then there's no need for deadheat, because all cars that can advance will advance, and there's no need to care about ties
     else{
       for(let i = 0; i < sortedResult.length; i++){
-        if(i < numSemiLanes ){
+        if(i < checkNumAdvances ){
           advanceToSemis.push({
             carId: sortedResult[i].carId,
             aggResults: sortedResult[i].aggResults,
@@ -369,6 +382,8 @@ export class RaceService {
         }
       }
     }
+
+    //TODO: revisit when numAdvances gets set, and what to do with the cars that do advance
 
     this.numAdvances.setnumAdvances(advanceToSemis.length);
 

--- a/server/src/race/semi.service.ts
+++ b/server/src/race/semi.service.ts
@@ -4,11 +4,30 @@ import { Injectable } from '@nestjs/common';
 export class SemiGlobalVariableService {
   private numAdvances: number  = 0;
 
+  private advanceToSemis = [
+    { 
+      carId: 0,
+      aggResults: 0, 
+    },
+  ];
+
   getNumAdvances(): number {
     return this.numAdvances;
   }
 
   setnumAdvances(value: number): void {
     this.numAdvances = value;
+  }
+
+  getAdvanceToSemis() {
+    return this.advanceToSemis;
+  }
+
+  setAdvanceToSemis(data){    
+    this.advanceToSemis = data;
+  }
+
+  initAdvanceToSemis(){
+    this.advanceToSemis.length = 0;
   }
 }

--- a/server/src/race/semi.service.ts
+++ b/server/src/race/semi.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class SemiGlobalVariableService {
+  private numAdvances: number  = 0;
+
+  getNumAdvances(): number {
+    return this.numAdvances;
+  }
+
+  setnumAdvances(value: number): void {
+    this.numAdvances = value;
+  }
+}


### PR DESCRIPTION
Bunch of logic to create deadheats and create semis, including if there are deadheats to draw from.

Couple bugs to work out:
- if everything is a deadheat, there's an error on counter in the create heats logic
- when creating semis and quarterfinaldeadheats the shuffle doesn't appear to be working right, because the heat assignments are repeating the same lane assignments 